### PR TITLE
Fix #4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ repositories {
 dependencies {
     minecraft 'net.minecraftforge:forge:1.16.4-35.1.36'
     // GeckoLib
-    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.16.5:3.0.12')
+    implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.16.5:3.0.16')
     // CryptMaster
     implementation fg.deobf('cryptcraft:cryptmaster:0.3.0-forge')
     runtimeOnly fg.deobf('me.shedaniel.architectury:architectury:1.5.112-forge')

--- a/src/main/java/denimred/simplemuseum/client/renderer/entity/MuseumDummyModel.java
+++ b/src/main/java/denimred/simplemuseum/client/renderer/entity/MuseumDummyModel.java
@@ -15,7 +15,7 @@ import software.bernie.geckolib3.core.IAnimatable;
 import software.bernie.geckolib3.core.builder.Animation;
 import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.processor.IBone;
-import software.bernie.geckolib3.geo.exception.GeoModelException;
+import software.bernie.geckolib3.geo.exception.GeckoLibException;
 import software.bernie.geckolib3.geo.render.built.GeoModel;
 import software.bernie.geckolib3.model.AnimatedGeoModel;
 import software.bernie.geckolib3.model.provider.data.EntityModelData;
@@ -31,7 +31,7 @@ public class MuseumDummyModel extends AnimatedGeoModel<MuseumDummyEntity> {
     public GeoModel getModel(ResourceLocation location) {
         try {
             return super.getModel(location);
-        } catch (GeoModelException e) {
+        } catch (GeckoLibException e) {
             // Emergency fallback for when we render while resources are reloading
             SimpleMuseum.LOGGER.debug("EMERGENCY FALLBACK: Model '{}'", location);
             return super.getModel(MuseumDummyEntity.DEFAULT_MODEL_LOCATION);
@@ -63,7 +63,7 @@ public class MuseumDummyModel extends AnimatedGeoModel<MuseumDummyEntity> {
     public Animation getAnimation(String name, IAnimatable animatable) {
         try {
             return super.getAnimation(name, animatable);
-        } catch (NullPointerException e) {
+        } catch (GeckoLibException e) {
             // Emergency fallback for when we render while resources are reloading
             SimpleMuseum.LOGGER.debug("EMERGENCY FALLBACK: Animation '{}'", name);
             return null;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -30,7 +30,7 @@ side = "BOTH"
 [[dependencies.simplemuseum]]
 modId="geckolib3"
 mandatory=true
-versionRange="[3,)"
+versionRange="[3.0.15,)"
 ordering="AFTER"
 side = "BOTH"
 [[dependencies.simplemuseum]]


### PR DESCRIPTION
Updates GeckoLib to 3.0.16, with 3.0.15 being the minimum loadable version.